### PR TITLE
[Snap] Add `dotnet9` extension and desktop entry support

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,9 +14,9 @@ description: |
   - Privacy Focused: All user data is stored locally on your device
   - Available on Windows, Linux, Android, iOS, macOS, and as a web app
   - Localized to English, German, Spanish, Slovenian, French, Portuguese, Italian, Japanese, Chinese, Korean, Dutch, Danish, Norwegian, Swedish, Finnish, Polish, Czech, Slovak, Croatian, Serbian
-  
+
   Key Features:
-  
+
   - Markdown support for notes
   - Use categories and priorities to organize your notes, tasks, and habits
   - Advanced Search, Filter, and Sort
@@ -36,19 +36,26 @@ parts:
     # dotnet-self-contained-runtime-identifier: linux-x64
     dotnet-version: "9.0"
     dotnet-configuration: "Release"
-    dotnet-self-contained: true
     dotnet-build-framework: "net9.0"
     dotnet-verbosity: "normal"
-    override-build: |
-     dotnet publish OpenHabitTracker.Blazor.Photino/OpenHabitTracker.Blazor.Photino.csproj -c Release -f net9.0 -r linux-x64 -p:PublishSingleFile=true -p:SelfContained=true -o $SNAPCRAFT_PART_INSTALL
-     chmod 0755 $SNAPCRAFT_PART_INSTALL/OpenHT
+    dotnet-project: OpenHabitTracker.Blazor.Photino/OpenHabitTracker.Blazor.Photino.csproj
+    dotnet-properties:
+      PublishSingleFile: "true"
     # build-packages:
     #   - dotnet-sdk-9.0
+    override-build: |
+      craftctl default
+      # Replace content of .desktop file
+      cp net.openhabittracker.OpenHabitTracker.desktop $CRAFT_PART_INSTALL
+      sed -i "s|Exec=OpenHT|Exec=openhabittracker|g" $CRAFT_PART_INSTALL/net.openhabittracker.OpenHabitTracker.desktop
+      sed -i "s|Icon=net.openhabittracker.OpenHabitTracker|Icon=$SNAP/meta/gui/icon.svg|g" \
+        $CRAFT_PART_INSTALL/net.openhabittracker.OpenHabitTracker.desktop
 
 apps:
   openhabittracker:
-    extensions: [gnome]
+    extensions: [ gnome, dotnet9 ]
     command: OpenHT
+    desktop: net.openhabittracker.OpenHabitTracker.desktop
     plugs:
       - hardware-observe
       - home


### PR DESCRIPTION
Hello @Jinjinov! This PR makes some adjustments to the `snapcraft.yaml` file of your application to make it leaner and more user-friendly.

### Added the `dotnet9` extension

Using the `dotnet9` extension ensures that you don't need to build your application as self-contained. It automatically wires up your snap to the .NET 9 content snap, which provides the runtime binaries to support running your application.

The .NET 9 content snap is a separate snap that is automatically installed when installing your application's snap. It is a regular snap shared by all .NET application snaps in the user's system, avoiding the duplication of each snap shipping its own runtime.

Because of that, the snap package size gets smaller, from 37 MB to 26 MB. And the `OpenHT` executable, when the snap is installed, also shrinks from 78 MB to just 11 MB.

.NET extensions docs: https://documentation.ubuntu.com/snapcraft/latest/reference/extensions/dotnet-extensions/

> [!NOTE]
> The .NET extensions are currently in experimental mode, which means that you have to set the environment variable `SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1` before running `snapcraft pack`.

I have also removed the `override-build` section, which was unnecessary given that the plugin already handles the publishing of the application.

### Added desktop entry support

I have moved the `snapcraft.yaml` file to a directory called `snap` and created the `snap/gui` directory with the app's `.desktop` file and icon to ensure that snapd correctly adds the desktop entry to the user's menu with the correct icon when the snap is installed. This was previously missing.